### PR TITLE
AbstractMetaClasses now hold the instantiation types for the templates they implement.

### DIFF
--- a/abstractmetabuilder.cpp
+++ b/abstractmetabuilder.cpp
@@ -2564,11 +2564,8 @@ bool AbstractMetaBuilder::inheritTemplate(AbstractMetaClass* subclass,
         subclass->addFunction(f);
     }
 
-    // Clean up
-    foreach (AbstractMetaType *type, templateTypes)
-        delete type;
-
     subclass->setTemplateBaseClass(templateClass);
+    subclass->setTemplateBaseClassInstantiations(templateTypes);
     subclass->setInterfaces(templateClass->interfaces());
     subclass->setBaseClass(templateClass->baseClass());
 

--- a/abstractmetalang.cpp
+++ b/abstractmetalang.cpp
@@ -1065,6 +1065,10 @@ AbstractMetaClass::~AbstractMetaClass()
     qDeleteAll(m_fields);
     qDeleteAll(m_enums);
     qDeleteAll(m_orphanInterfaces);
+    if (hasTemplateBaseClassInstantiations()) {
+        foreach (AbstractMetaType* inst, templateBaseClassInstantiations())
+            delete inst;
+    }
 }
 
 /*******************************************************************************
@@ -1544,7 +1548,29 @@ QPropertySpec *AbstractMetaClass::propertySpecForReset(const QString &name) cons
     return 0;
 }
 
+typedef QHash<const AbstractMetaClass*, AbstractMetaTypeList> AbstractMetaClassBaseTemplateInstantiationsMap;
+Q_GLOBAL_STATIC(AbstractMetaClassBaseTemplateInstantiationsMap, metaClassBaseTemplateInstantiations);
 
+bool AbstractMetaClass::hasTemplateBaseClassInstantiations() const
+{
+    if (!templateBaseClass())
+        return false;
+    return metaClassBaseTemplateInstantiations()->contains(this);
+}
+
+AbstractMetaTypeList AbstractMetaClass::templateBaseClassInstantiations() const
+{
+    if (!templateBaseClass())
+        return AbstractMetaTypeList();
+    return metaClassBaseTemplateInstantiations()->value(this);
+}
+
+void AbstractMetaClass::setTemplateBaseClassInstantiations(AbstractMetaTypeList& instantiations)
+{
+    if (!templateBaseClass())
+        return;
+    metaClassBaseTemplateInstantiations()->insert(this, instantiations);
+}
 
 static bool functions_contains(const AbstractMetaFunctionList &l, const AbstractMetaFunction *func)
 {

--- a/abstractmetalang.h
+++ b/abstractmetalang.h
@@ -1874,6 +1874,10 @@ public:
         m_templateBaseClass = cls;
     }
 
+    bool hasTemplateBaseClassInstantiations() const;
+    AbstractMetaTypeList templateBaseClassInstantiations() const;
+    void setTemplateBaseClassInstantiations(AbstractMetaTypeList& instantiations);
+
     void setTypeAlias(bool typeAlias)
     {
         m_isTypeAlias = typeAlias;

--- a/tests/testtemplates.h
+++ b/tests/testtemplates.h
@@ -38,6 +38,7 @@ private slots:
     void testInheritanceFromContainterTemplate();
     void testTemplateInheritanceMixedWithForwardDeclaration();
     void testTemplateInheritanceMixedWithNamespaceAndForwardDeclaration();
+    void testTypedefOfInstantiationOfTemplateClass();
 };
 
 #endif


### PR DESCRIPTION
AbstractMetaClasses that are typedefs for template class instantiations
use to keep the template from where they derive, but didn't keep the
values used for the derivation. Now this is fixed, and with an unit test.
