### PR TITLE
Fixed compilation error for gcc versions < 4

### DIFF
--- a/apiextractormacros.h
+++ b/apiextractormacros.h
@@ -17,7 +17,7 @@
 
 #ifndef APIEXTRACTOR_API
     #define APIEXTRACTOR_API
-    #define APIEXTRACTOR_API(func) func
+    #define APIEXTRACTOR_DEPRECATED(func) func
 #endif
 
 #endif


### PR DESCRIPTION
apiextractormacros.h does not compile with gcc 3.x because it declares APIEXTRACTOR_API twice. The attached patch fixes this issue by correctly declaring APIEXTRACTOR_DEPRECATED instead.
