### PR TITLE
Fix BUG #1086 - "generatorrunner segfault processing #include..."

### DIFF
--- a/parser/rpp/pp-engine.h
+++ b/parser/rpp/pp-engine.h
@@ -143,6 +143,7 @@ class pp
 
     enum PP_DIRECTIVE_TYPE {
         PP_UNKNOWN_DIRECTIVE,
+        PP_UNNAMED_DIRECTIVE,
         PP_DEFINE,
         PP_INCLUDE,
         PP_INCLUDE_NEXT,


### PR DESCRIPTION
Boost headers typically include the character '#' at the beginning of
any line and just do nothing elese with that unnamed directive. So as
that's not actually an error, rather that's just a just-do-nothing
directive we'll ignore this situtation. There's still a problem when
using #include directives and passing macros as arguments rather than a
path to the header file. Instead of asserting this issue we'll print a
fatal message about this issue and then aborting.

One can also include a path between brackets (for e.g., when defining a
macro or so) so that we cannot simply ignore that. So we need to handle
this kind of stuff as well.

Signed-off-by: Paulo Alcantara pcacjr@gmail.com
